### PR TITLE
bugfix/CRM-1206-Typo in "Contributions (Detailed)","Activities (Detailed)","Contacts (Detailed)","Recurring Contributions (Detailed)" Report Template when you select "Create New Report" with SuperAdmin cred

### DIFF
--- a/CRM/Reportorganizer/Page/ReportTemplateList.php
+++ b/CRM/Reportorganizer/Page/ReportTemplateList.php
@@ -55,15 +55,15 @@ LEFT  JOIN civicrm_component comp
     global $user;
     if (in_array('client administrator', $user->roles)) {
       $hiddenTemplates = [
-        'Contributions (Detailled)',
+        'Contributions (Detailed)',
         'Contributions (Extended, Summary)',
         'Contributions (Extended, Pivot Chart)',
         'Contributions (Extended, Extra Fields)',
-        'Recurring Contributions (Detailled)',
+        'Recurring Contributions (Detailed)',
         'Recurring Contributions (Extended, Pivot Chart)',
-        'Contacts (Detailled)',
+        'Contacts (Detailed)',
         'Contacts (Extended, Pivot Chart)',
-        'Activities (Detailled)',
+        'Activities (Detailed)',
         'Activities (Extended)',
         'Activities (Extended, Pivot Chart)',
         'Opportunity Report (Detailled)',
@@ -200,7 +200,7 @@ LEFT  JOIN civicrm_component comp
     $instanceSections = [
       "General Contribution Reports" => [
         "Contributions (Summary)",
-        "Contributions (Detailled)",
+        "Contributions (Detailed)",
         "Repeat Contributions",
         "Top Donors",
         "SYBUNT",
@@ -217,7 +217,7 @@ LEFT  JOIN civicrm_component comp
       ],
       "Recurring Contribution Reports" => [
         "Recurring Contributions (Summary)",
-        "Recurring Contributions (Detailled)",
+        "Recurring Contributions (Detailed)",
         "Recurring Contributions (Extended, Pivot Chart)",
         "Recurring Contributions (Detailed)",
       ],
@@ -236,7 +236,7 @@ LEFT  JOIN civicrm_component comp
     $instanceSections = [
       "General Contact Reports" => [
         "Contacts (Summary)",
-        "Contacts (Detailled)",
+        "Contacts (Detailed)",
         "Contacts (Detailed)",
         "Contacts (Extended, Pivot Chart)",
         "Database Log",
@@ -244,7 +244,7 @@ LEFT  JOIN civicrm_component comp
       ],
       "Activity Reports" => [
         "Activities (Summary)",
-        "Activities (Detailled)",
+        "Activities (Detailed)",
         "Activities (Extended)",
         "Activities (Extended, Pivot Chart)",
         "Activities (Detailed)",

--- a/CRM/Reportorganizer/Page/ReportTemplateList.php
+++ b/CRM/Reportorganizer/Page/ReportTemplateList.php
@@ -66,7 +66,7 @@ LEFT  JOIN civicrm_component comp
         'Activities (Detailed)',
         'Activities (Extended)',
         'Activities (Extended, Pivot Chart)',
-        'Opportunity Report (Detailled)',
+        'Opportunity Report (Detailed)',
         'Opportunity Report (Statistics)',
         'Grant Report (Detailled)',
         'Grant Report (Statistics)',

--- a/CRM/Reportorganizer/Page/ReportTemplateList.php
+++ b/CRM/Reportorganizer/Page/ReportTemplateList.php
@@ -68,7 +68,7 @@ LEFT  JOIN civicrm_component comp
         'Activities (Extended, Pivot Chart)',
         'Opportunity Report (Detailed)',
         'Opportunity Report (Statistics)',
-        'Grant Report (Detailled)',
+        'Grant Report (Detailed)',
         'Grant Report (Statistics)',
 	      'Membership Report (Summary)',
 	      'Membership Report (Detail)',

--- a/CRM/Reportorganizer/Upgrader.php
+++ b/CRM/Reportorganizer/Upgrader.php
@@ -225,45 +225,15 @@ class CRM_Reportorganizer_Upgrader extends CRM_Reportorganizer_Upgrader_Base {
   public function upgrade_4211() {
     $this->ctx->log->info('CRM-1206-Typo in "Contributions (Detailed)" Report Template when you select "Create New Report" with SuperAdmin cred.'); // PEAR Log interface
 
-    $optionGroups = civicrm_api4('OptionGroup', 'get', [
-      'select' => [
-        'id',
-      ],
-      'where' => [
-        ['name', '=', 'report_template'],
-      ],
-      'chain' => [
-        'reportOptionValue' => ['OptionValue', 'get', [
-          'select' => [
-            'id',
-            'label',
-          ],
-          'where' => [
-            ['option_group_id', '=', '$id'], 
-            ['name', 'IN', ['CRM_Report_Form_Contact_Detail', 'CRM_Report_Form_Activity', 'CRM_Report_Form_Contribute_Detail', 'CRM_Report_Form_Contribute_Recur']],
-          ]
-        ]],
-      ],
-    ]);
-    foreach($optionGroups as $k=>$v)
-    {
-      if($v['reportOptionValue'])
-      {
-        foreach($v['reportOptionValue'] as $reportKey=>$reportValue)
-        {
-          $replacedValue = str_replace('Detailled', 'Detailed', $reportValue['label']);
-          $id = $reportValue['id'];
-          $results = civicrm_api4('OptionValue', 'update', [
-            'values' => [
-              'label' => $replacedValue,
-            ],
-            'where' => [
-              ['id', '=', $id],
-            ],
-          ]);
-        }
-      }
-    }
+    $reportLabelUpdateData =   ['CRM_Report_Form_Contact_Detail' => 'Contacts (Detailed)', 
+  'CRM_Report_Form_Activity' => 'Activities (Detailed)', 
+  'CRM_Report_Form_Contribute_Detail'=> 'Contributions (Detailed)', 
+  'CRM_Report_Form_Contribute_Recur'=>'Recurring Contributions (Detailed)'];
+  foreach($reportLabelUpdateData as $reportKey =>$reportValue)
+  {
+    $sql = "UPDATE `civicrm_option_value` SET `label`='$reportValue' WHERE `name` = '$reportKey' AND `option_group_id` = (SELECT `id` from `civicrm_option_group` WHERE `name` = 'report_template')";
+    CRM_Core_DAO::executeQuery($sql);
+  }
     return TRUE;
   }
 

--- a/CRM/Reportorganizer/Upgrader.php
+++ b/CRM/Reportorganizer/Upgrader.php
@@ -222,6 +222,51 @@ class CRM_Reportorganizer_Upgrader extends CRM_Reportorganizer_Upgrader_Base {
     }
   }
 
+  public function upgrade_4211() {
+    $this->ctx->log->info('CRM-1206-Typo in "Contributions (Detailed)" Report Template when you select "Create New Report" with SuperAdmin cred.'); // PEAR Log interface
+
+    $optionGroups = civicrm_api4('OptionGroup', 'get', [
+      'select' => [
+        'id',
+      ],
+      'where' => [
+        ['name', '=', 'report_template'],
+      ],
+      'chain' => [
+        'reportOptionValue' => ['OptionValue', 'get', [
+          'select' => [
+            'id',
+            'label',
+          ],
+          'where' => [
+            ['option_group_id', '=', '$id'], 
+            ['name', 'IN', ['CRM_Report_Form_Contact_Detail', 'CRM_Report_Form_Activity', 'CRM_Report_Form_Contribute_Detail', 'CRM_Report_Form_Contribute_Recur']],
+          ]
+        ]],
+      ],
+    ]);
+    foreach($optionGroups as $k=>$v)
+    {
+      if($v['reportOptionValue'])
+      {
+        foreach($v['reportOptionValue'] as $reportKey=>$reportValue)
+        {
+          $replacedValue = str_replace('Detailled', 'Detailed', $reportValue['label']);
+          $id = $reportValue['id'];
+          $results = civicrm_api4('OptionValue', 'update', [
+            'values' => [
+              'label' => $replacedValue,
+            ],
+            'where' => [
+              ['id', '=', $id],
+            ],
+          ]);
+        }
+      }
+    }
+    return TRUE;
+  }
+
   /**
    * Example: Run an external SQL script when the module is uninstalled.
    */

--- a/CRM/Reportorganizer/Utils.php
+++ b/CRM/Reportorganizer/Utils.php
@@ -111,7 +111,7 @@ class CRM_Reportorganizer_Utils {
         "description" => "All Contacts",
       ],
       "Constituent Report (Detail)" => [
-        "label" => "Contacts (Detailled)",
+        "label" => "Contacts (Detailed)",
         "description" => "All Contacts with extra fields",
       ],
       "Extended Report - Flexible contact report" => [
@@ -136,7 +136,7 @@ class CRM_Reportorganizer_Utils {
         "description" => "Total amounts raised",
       ],
       "Contribution Detail Report" => [
-        "label" => "Contributions (Detailled)",
+        "label" => "Contributions (Detailed)",
         "description" => "Total amounts raised with individual Contribution information",
       ],
       "Repeat Contributions Report" => [
@@ -197,7 +197,7 @@ class CRM_Reportorganizer_Utils {
         "description" => "Total amounts raised from Recurring Contributions by each Payment Method",
       ],
       "Recurring Contributions Report" => [
-        "label" => "Recurring Contributions (Detailled)",
+        "label" => "Recurring Contributions (Detailed)",
         "description" => "Total amounts raised for Recurring Contributions",
       ],
       "Extended Report - Recurring Contribution Pivot Chart" => [
@@ -223,7 +223,7 @@ class CRM_Reportorganizer_Utils {
         "description" => "All Activities by type and date information",
       ],
       "Activity Details Report" => [
-        "label" => "Activities (Detailled)",
+        "label" => "Activities (Detailed)",
         "description" => "All Activities",
       ],
       "Extended Report - Activities" => [
@@ -319,7 +319,7 @@ class CRM_Reportorganizer_Utils {
       $contribComponent => [
         "General Contribution Reports" => [
           "Contributions (Summary)",
-          "Contributions (Detailled)",
+          "Contributions (Detailed)",
           "Repeat Contributions",
           "Top Donors",
           "SYBUNT",
@@ -336,7 +336,7 @@ class CRM_Reportorganizer_Utils {
         ],
         "Recurring Contribution Reports" => [
           "Recurring Contributions (Summary)",
-          "Recurring Contributions (Detailled)",
+          "Recurring Contributions (Detailed)",
           "Recurring Contributions (Extended, Pivot Chart)",
           "Recurring Contributions (Detailed)",
         ],
@@ -348,7 +348,7 @@ class CRM_Reportorganizer_Utils {
       $contactComponent => [
         "General Contact Reports" => [
           "Contacts (Summary)",
-          "Contacts (Detailled)",
+          "Contacts (Detailed)",
           "Contacts (Detailed)",
           "Contacts (Extended, Pivot Chart)",
           "Database Log",
@@ -356,7 +356,7 @@ class CRM_Reportorganizer_Utils {
         ],
         "Activity Reports" => [
           "Activities (Summary)",
-          "Activities (Detailled)",
+          "Activities (Detailed)",
           "Activities (Extended)",
           "Activities (Extended, Pivot Chart)",
           "Activities (Detailed)",


### PR DESCRIPTION
corrected typos for the following four report types.

"Contributions (Detailed)"
"Activities (Detailed)"
"Contacts (Detailed)"
"Recurring Contributions (Detailed)" 